### PR TITLE
fix: #9 converter breaks with custom port rate

### DIFF
--- a/plugin2889/const.py
+++ b/plugin2889/const.py
@@ -157,7 +157,7 @@ class PortGroup(Enum):
 
 class PortRateCapProfile(Enum):
     PHYSICAL = "physical_port_rate"
-    CUSTOM = "custom_rate_cap"
+    CUSTOM = "custom"
 
     @property
     def is_custom(self) -> bool:


### PR DESCRIPTION
keep the same value as valkyrie using "custom"